### PR TITLE
Autoscale the minimum values in the fid drift plots

### DIFF
--- a/plot_drift.py
+++ b/plot_drift.py
@@ -68,12 +68,12 @@ def plotfids(detstats, det, data_dir):
             min_plot_y = fid_min - (fid_min % 5)
         plt.subplot(2, 1, 1)
         plt.plot(year - year0, fidstats['ang_y_med'] - y0,
-                 ',', markerfacecolor=fidcolor[fid], mew=0,
+                 '.', markersize=4, markerfacecolor=fidcolor[fid], mew=0,
                  scaley=False, scalex=False)
         plt.ylim(ymin=min_plot_y)
         plt.subplot(2, 1, 2)
         plt.plot(year - year0, fidstats['ang_z_med'] - z0 + fidstats['sim_z_offset'] - sim_z_nom,
-                 ',', markerfacecolor=fidcolor[fid], mew=0,
+                 '.', markersize=4, markerfacecolor=fidcolor[fid], mew=0,
                  scaley=False, scalex=False)
         plt.ylim(ymin=min_plot_y)
     plt.savefig(os.path.join(data_dir, 'drift_%s.png' % re.sub(r'-', '_', det.lower())))


### PR DESCRIPTION
Autoscaling in Y should allow us to see the outliers in the direction of interest.

This set of changes also includes rejection of 4 early obsids that produced large (500 -> 1000) arcsec outliers in the plots.  I assume that these are corrupt in the database (labeled with the incorrect fid id or the like) but have not had a chance to investigate.  I figured it made more sense to just reject the data from these specifc obsids than to do any limit filtering on the fid position data.
