### PR TITLE
Problem with fids for observations not yet in sybase starcheck table

### DIFF
--- a/plot_starcheck_vs_telem.py
+++ b/plot_starcheck_vs_telem.py
@@ -71,7 +71,10 @@ def get_fids_starcheck(dwells):
             fids = db.fetchall('SELECT obsid, slot, yang, zang FROM starcheck_catalog '
                                'WHERE obsid={} AND type="FID"'
                                .format(obsid))
-            fids_starcheck[obsid] = Table(fids)
+            if len(fids) > 0:
+                fids_starcheck[obsid] = Table(fids)
+            else:
+                logger.info('No fids found for obsid {} in starcheck_catalog'.format(obsid))
 
     return fids_starcheck
 


### PR DESCRIPTION
Suggest just catching problem when there are no fids and continuing.

```
WARNING - '/proj/sot/ska/share/fid_drift_mon/plot_starcheck_vs_telem.py --out /proj/sot/ska/data/fid_drift_mon/starcheck_telem.png' returned non-zero status: 256
Getting dwells betweeen 2013:359:16:20:31.090 and 2014:084:16:20:31.091
Skipping duplicate obsid 15192 for dwell start=2014:007:20:48:00.118 dur=23657
Skipping duplicate obsid 15192 for dwell start=2014:008:03:47:38.219 dur=28136
Skipping duplicate obsid 15192 for dwell start=2014:008:11:55:11.721 dur=18520
Skipping duplicate obsid 15192 for dwell start=2014:008:17:36:55.822 dur=17510
Skipping duplicate obsid 15192 for dwell start=2014:008:22:37:27.623 dur=190
Skipping duplicate obsid 15192 for dwell start=2014:008:23:06:54.723 dur=4784
Getting fids from sybase starcheck table
ERROR: ValueError: Inconsistent data column lengths: set([]) [astropy.table.table]
Traceback (most recent call last):
  File "/proj/sot/ska/share/fid_drift_mon/plot_starcheck_vs_telem.py", line 197, in <module>
    main()
  File "/proj/sot/ska/share/fid_drift_mon/plot_starcheck_vs_telem.py", line 188, in main
    fids_starcheck = get_fids_starcheck(dwells)
  File "/proj/sot/ska/share/fid_drift_mon/plot_starcheck_vs_telem.py", line 74, in get_fids_starcheck
    fids_starcheck[obsid] = Table(fids)
  File "/proj/sot/ska/arch/x86_64-linux_CentOS-5/lib/python2.7/site-packages/astropy-0.3-py2.7-linux-x86_64.egg/astropy/table/table.py", line 1117, in __init__
    init_func(data, names, dtype, n_cols, copy)
  File "/proj/sot/ska/arch/x86_64-linux_CentOS-5/lib/python2.7/site-packages/astropy-0.3-py2.7-linux-x86_64.egg/astropy/table/table.py", line 1260, in _init_from_list
    self._init_from_cols(cols)
  File "/proj/sot/ska/arch/x86_64-linux_CentOS-5/lib/python2.7/site-packages/astropy-0.3-py2.7-linux-x86_64.egg/astropy/table/table.py", line 1323, in _init_from_cols
    .format(lengths))
ValueError: Inconsistent data column lengths: set([])
```
