### PR TITLE
Cannot delete tempdir error

### DIFF
--- a/fid_drift_mon.pl
+++ b/fid_drift_mon.pl
@@ -35,6 +35,11 @@ our @loglines;                  # All logged messages (per obsid) get stored her
 
 my $tmp_data_dir = tempdir(CLEANUP => 1); #
 chdir $tmp_data_dir or die "Could not change to tmp dir '$tmp_data_dir'\n";
+# Use END block to always change out of that temp directory at the end of the program
+# This should help with cleanup of the directory
+END {
+    chdir("/");
+}
 
 # Mostly for reference, here is the table creation command
 my $create_table_sql = <<CREATE_TABLE_SQL;


### PR DESCRIPTION

ska-aca-fido% perl fid_drift_mon.pl
COMMAND LINE PARAMETERS
  loud             = 1

Fetching existing fid_stats obsids
Fetching mp_load_info obsids
Processing obsids 
cannot remove path when cwd is /tmp/bf1YqWSC8E for /tmp/bf1YqWSC8E:  at /proj/sot/ska/arch/x86_64-linux_CentOS-5/lib/perl5/5.8.9/File/Temp.pm line 901
