### PR TITLE
Only get dwells that have an obsid in kadi

### DIFF
--- a/plot_starcheck_vs_telem.py
+++ b/plot_starcheck_vs_telem.py
@@ -86,6 +86,9 @@ def get_dwells_with_fids(start, stop):
 
     :returns: dict of tables keyed by obsid (like starcheck fids)
     """
+    # Only get dwells that have an obsid
+    stop = min(DateTime(stop).date, events.obsids.all().reverse()[0].stop)
+
     logger.info('Getting dwells betweeen {} and {}'.format(start, stop))
     dwells = OrderedDict()
     for dwell in events.dwells.filter(start, stop):


### PR DESCRIPTION
Prompted by this, likely related to the recent SCS107 run:
```
WARNING - '/proj/sot/ska/share/fid_drift_mon/plot_starcheck_vs_telem.py --out /proj/sot/ska/data/fid_drift_mon/starcheck_telem.png' returned non-zero status: 256
Getting dwells betweeen 2015:085:16:19:35.819 and 2015:175:16:19:35.819
Traceback (most recent call last):
  File "/proj/sot/ska/share/fid_drift_mon/plot_starcheck_vs_telem.py", line 200, in <module>
    main()
  File "/proj/sot/ska/share/fid_drift_mon/plot_starcheck_vs_telem.py", line 190, in main
    dwells = get_dwells_with_fids(start.date, stop.date)
  File "/proj/sot/ska/share/fid_drift_mon/plot_starcheck_vs_telem.py", line 92, in get_dwells_with_fids
    obsid = dwell.get_obsid()
  File "/proj/sot/ska/arch/x86_64-linux_CentOS-5/lib/python2.7/site-packages/kadi/events/models.py", line 491, in get_obsid
    .format(start, obsids))
ValueError: Expected one obsid at 2015:173:13:53:58.065 but got
```
